### PR TITLE
Update containerd install scripts.

### DIFF
--- a/scripts/others/install-docker.sh
+++ b/scripts/others/install-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install docker binaries: https://docs.docker.com/engine/install/binaries/
-# Install containerd binaries: https://github.com/containerd/containerd/blob/main/docs/cri/installation.md
+# Install containerd binaries: https://github.com/containerd/containerd/blob/main/docs/getting-started.md#option-1-from-the-official-binaries
 
 set -e
 
@@ -8,13 +8,16 @@ set -e
 # Get stable version of Docker: https://download.docker.com/linux/static/stable
 DOCKER_VERSION="20.10.21"
 CONTAINERD_VERSION="1.6.9"
+CRICTL_VERSION="1.25.0"
 
 if [[ "$(uname -m)" == "aarch64" ]]; then
     DOCKER_ARCH="aarch64"
     CONTAINERD_ARCH="arm64"
+    CRICTL_ARCH="arm64"
 elif [[ "$(uname -m)" == "x86_64" ]]; then
     DOCKER_ARCH="x86_64"
     CONTAINERD_ARCH="amd64"
+    CRICTL_ARCH="amd64"
 else
     echo "Unrecognized arch $(uname -m)"
     exit 1
@@ -22,16 +25,66 @@ fi
 
 echo "Install docker ${DOCKER_VERSION} and containerd ${CONTAINERD_VERSION} for openEuler..."
 # Download containerd binaries
-wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-${CONTAINERD_ARCH}.tar.gz -O containerd.tar.gz
+wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${CONTAINERD_ARCH}.tar.gz -O containerd.tar.gz
+# Download crictl binaries
+wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-${CRICTL_ARCH}.tar.gz -O crictl.tar.gz
 # Download docker binaries
 wget https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz -O docker.tar.gz
 # Install containerd
 echo "Extracting containerd binaries..."
-sudo tar --no-overwrite-dir -C / -xzf ./containerd.tar.gz
+sudo tar Czxvf /usr/local containerd.tar.gz
+# Install crictl binary
+sudo tar Czxvf /usr/local/bin crictl.tar.gz
 # Install docker
 echo "Extracting docker binaries..."
 tar -zxf ./docker.tar.gz
 sudo cp -p docker/* /usr/bin
+
+# https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+sudo bash -c 'cat > /etc/systemd/system/containerd.service <<EOF
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+#uncomment to enable the experimental sbservice (sandboxed) version of containerd/cri integration
+#Environment="ENABLE_CRI_SANDBOXES=sandboxed"
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF'
 
 # https://github.com/moby/moby/tree/master/contrib/init/systemd
 sudo bash -c 'cat >/etc/systemd/system/docker.service <<EOF


### PR DESCRIPTION
## Update containerd install script

The package name with `cri-` prefix is [deprecated](https://github.com/containerd/containerd/blob/main/docs/cri/installation.md), update the install package without cri.

FYI <https://github.com/containerd/containerd/blob/main/docs/getting-started.md#option-1-from-the-official-binaries>.