### PR TITLE
Only add openeuler to docker group

### DIFF
--- a/scripts/others/install-docker.sh
+++ b/scripts/others/install-docker.sh
@@ -229,7 +229,7 @@ fi
 
 # Add docker user group
 sudo groupadd docker || echo -n ""
-sudo usermod -aG docker $USER
+sudo usermod -aG docker openeuler
 
 echo "Enabling and start docker services..."
 sudo systemctl daemon-reload


### PR DESCRIPTION
添加当前user($USER) 到docker group，本质上并没问题。

但是，如果把这个脚本通过cloud-init writefiles 再运行时，就会发生问题，因为cloud-init执行脚本时无法识别  $USER 。

以较为通用的场景考虑，默认就添加openeuler user到docker group。