### PR TITLE
PANDARIA: Fix the shell execution error when the openeuler role does …

### DIFF
--- a/scripts/others/install-docker.sh
+++ b/scripts/others/install-docker.sh
@@ -229,7 +229,8 @@ fi
 
 # Add docker user group
 sudo groupadd docker || echo -n ""
-sudo usermod -aG docker openeuler
+sudo usermod -aG docker openeuler || echo -n ""
+sudo usermod -aG docker $USER || echo -n ""
 
 echo "Enabling and start docker services..."
 sudo systemctl daemon-reload


### PR DESCRIPTION
### 问题

当创建使用 openeuler 的镜像创建 ecs 时，默认的用户并没有 openeuler 这导致了执行安装脚本出错

### 解决的方式

把当前用户添加到 docker 组里